### PR TITLE
MID-361: provide JSON instead of string as body to got post method

### DIFF
--- a/victorops-twilio.js
+++ b/victorops-twilio.js
@@ -971,7 +971,7 @@ function postToVictorOps (event, context, payload) {
       {
         json: true,
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(alert)
+        body: alert
       }
     )
     .then(response => {


### PR DESCRIPTION
Change to address breaking change introduced in npm "got" module version 7.0.0.